### PR TITLE
Fixed supporting multiline banner_string defined in the pillar.

### DIFF
--- a/openssh/banner.sls
+++ b/openssh/banner.sls
@@ -7,8 +7,7 @@ sshd_banner:
   file.managed:
     - name: {{ openssh.banner }}
     {% if openssh.banner_string is defined %}
-    - contents: |
-        {{ openssh.banner_string }}
+    - contents: {{ openssh.banner_string | yaml }}
     {% else %}
     - source: {{ openssh.banner_src }}
     - template: jinja


### PR DESCRIPTION
Fixed rendering openssh.banner state with multiline banner_string defined in the pillar.

The pillar:
```
 openssh:                                                             
   banner_string: |                                                   
     Welcome to {{ grains['id'] }}.                                   
     This machine is managed using SaltStack.                         
     Do NOT modify any system settings.                               
     Changes will either get lost or interfere with the machine setup.
```

The rendering error fixed in this pull request:
```
salt-master:
    Data failed to compile:
----------
    Rendering SLS 'base:openssh.banner' failed: could not found expected ':'; line 13

---
[...]
    - name: /etc/ssh/banner

    - contents: |
        Welcome to salt-master.
This machine is managed using SaltStack.
Do NOT modify any system settings.    <======================
Changes will either get lost or interfere with the machine setup.
```